### PR TITLE
Update base image and storops

### DIFF
--- a/cinder/Changelist.md
+++ b/cinder/Changelist.md
@@ -2,3 +2,4 @@
 | ---- | ------------- | ------- | ---------- | ---------- |
 | 16.0-2 | 4.0.0 | Initial version of RHOSP16, storops 1.2.3 | 2020-03-10 | Manual |
 | 16.0-3 | 4.0.0 | Update base image | 2020-04-07 | Manual |
+| 16.0-4 | 4.0.0 | Update base image from 16.0-90 to 16.0-95, update storops from 1.2.3 to 1.2.5 | 2020-06-05 | Manual |

--- a/cinder/Dockerfile
+++ b/cinder/Dockerfile
@@ -1,9 +1,9 @@
   # Cinder driver container for Dell EMC VNX and Unity
 # Using openstack-cinder-volume base image
 
-FROM registry.redhat.io/rhosp-rhel8/openstack-cinder-volume:16.0-90
+FROM registry.redhat.io/rhosp-rhel8/openstack-cinder-volume:16.0-95
 
-ARG storops_version=1.2.3
+ARG storops_version=1.2.5
 
 LABEL maintainer="Dell EMC" \
       description="Red Hat OpenStack Platform 16.0 cinder-volume Dell EMC VNX and Unity" \

--- a/manila/Changelist.md
+++ b/manila/Changelist.md
@@ -2,3 +2,4 @@
 | ---- | ------------- | ------- | ---------- | ---------- |
 | 16.0-2 | 4.0.0 | Initial version of RHOSP16, storops 1.2.3 | 2020-03-10 | Manual |
 | 16.0-3 | 4.0.0 | Update base image | 2020-04-07 | Manual |
+| 16.0-4 | 4.0.0 | Update base image from 16.0-95 to 16.0-100, update storops from 1.2.3 to 1.2.5 | 2020-06-05 | Manual |

--- a/manila/Dockerfile
+++ b/manila/Dockerfile
@@ -1,9 +1,9 @@
 # Manila driver container for Dell EMC Unity
 # Using openstack-manila-share base image
 
-FROM registry.redhat.io/rhosp-rhel8/openstack-manila-share:16.0-95
+FROM registry.redhat.io/rhosp-rhel8/openstack-manila-share:16.0-100
 
-ARG storops_version=1.2.3
+ARG storops_version=1.2.5
 
 LABEL maintainer="Dell EMC" \
       description="Red Hat OpenStack Platform 16.0 manila-share Dell EMC Unity" \


### PR DESCRIPTION
Major changes:

Cinder:
* Update base image from 16.0-90 to 16.0-95
* Update storops from 1.2.3 to 1.2.5

Manila:
* Update base image from 16.0-95 to 16.0-100
* Update storops from 1.2.3 to 1.2.5